### PR TITLE
Add configurable trust proxy for correct protocol detection behind load balancers

### DIFF
--- a/.claude/project-structure.md
+++ b/.claude/project-structure.md
@@ -51,6 +51,7 @@ From `config/environment.js`. All values are overridable via environment variabl
 | Option              | Type              | Default                       | Env Var                    | Description                                                     |
 |---------------------|-------------------|-------------------------------|----------------------------|-----------------------------------------------------------------|
 | `enableHealthCheck` | **Boolean**       | `true`                        | `REST_HEALTH_CHECK_DISABLE=true` to disable | Registers `GET /health` returning 200                     |
+| `trustProxy`        | **Boolean**       | `false`                       | `REST_TRUST_PROXY=true` to enable           | Trust reverse proxy headers (`X-Forwarded-Proto`) for correct protocol detection behind load balancers |
 | `origin`            | **String**        | `'*'`                         | `REST_CORS_ORIGIN`         | CORS allowed origin(s)                                          |
 | `methods`           | **String**        | `'GET,POST,PATCH,PUT,DELETE'` | `REST_CORS_METHODS`        | CORS allowed methods                                            |
 | `dir`               | **String**        | `'./requests'`                | `REST_REQUEST_PATH`        | Directory containing Request class files to mount as routes     |

--- a/README.md
+++ b/README.md
@@ -75,7 +75,20 @@ Configuration is read from `stonyx/config` under `restServer`:
 |      `origin`     | **String \| Array** | `'*'`       | CORS origin(s) allowed                                     |
 |    `methods`      | **String**          | `'GET,POST,PATCH,PUT,DELETE'` | CORS allowed methods                              |
 | `enableHealthCheck` |   **Boolean**     | `true`      | Register `GET /health` endpoint (disable via `REST_HEALTH_CHECK_DISABLE=true`) |
+|  `trustProxy`   |     **Boolean**     | `false`     | Trust reverse proxy headers (e.g. `X-Forwarded-Proto`). Enable via `REST_TRUST_PROXY=true` when running behind a load balancer such as AWS ALB/ELB to ensure correct protocol detection. |
 |    `statusMap`    |      **Object**     | `{}`        | Optional mapping of HTTP status codes to custom messages   |
+
+### Running Behind a Load Balancer
+
+When your application runs behind a reverse proxy or load balancer (e.g. AWS ALB/ELB), the load balancer terminates SSL and forwards requests to your server over HTTP internally. This means Express sees `http` as the protocol even though the original client request used `https`.
+
+To fix this, enable the `trustProxy` option:
+
+```bash
+REST_TRUST_PROXY=true
+```
+
+This tells Express to trust the `X-Forwarded-Proto` header set by the load balancer, so `request.protocol` correctly returns `https`. This is important for any functionality that generates URLs based on the incoming request protocol, such as JSON:API relationship links.
 
 ## Request Class
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -3,7 +3,8 @@ const {
   REST_CORS_METHODS,
   REST_HEALTH_CHECK_DISABLE,
   REST_PORT,
-  REST_REQUEST_PATH
+  REST_REQUEST_PATH,
+  REST_TRUST_PROXY
 } = process;
 
 export default {
@@ -12,6 +13,7 @@ export default {
   methods: REST_CORS_METHODS ?? 'GET,POST,PATCH,PUT,DELETE',
   dir: REST_REQUEST_PATH ?? './requests',
   port: REST_PORT ?? 2666,
+  trustProxy: REST_TRUST_PROXY === 'true',
   logColor: 'yellow',
   logMethod: 'api'
 };

--- a/src/main.js
+++ b/src/main.js
@@ -61,7 +61,9 @@ export default class RestServer {
   }
 
   async setupGlobalMiddleware() {
-    const { origin, methods } = config.restServer;
+    const { origin, methods, trustProxy } = config.restServer;
+
+    if (trustProxy) this.api.set('trust proxy', true);
 
     this.api.use([
       cors({ origin, methods }),


### PR DESCRIPTION
## Summary

Adds a `trustProxy` configuration option (`REST_TRUST_PROXY=true`) that enables Express's `trust proxy` setting. This ensures `request.protocol` correctly reflects the original client protocol (e.g. `https`) when the server runs behind a reverse proxy or load balancer that terminates SSL.

## Changes

- Added `REST_TRUST_PROXY` env var and `trustProxy` config option (defaults to `false`) in `config/environment.js`
- Applied `app.set('trust proxy', true)` in `setupGlobalMiddleware()` when `trustProxy` is enabled
- Added `trustProxy` to the README configuration table and a new "Running Behind a Load Balancer" section
- Updated `.claude/project-structure.md` configuration reference table