### PR TITLE
fix: context review -- update stale file tree

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -106,12 +106,16 @@ Delegates to `abofs/stonyx-workflows/.github/workflows/npm-publish.yml@main`.
 ```
 stonyx-rest-server/
 ├── .claude/
-│   ├── improvements.md
-│   └── project-structure.md      # this file
+│   └── CLAUDE.md                  # Agent entry point
 ├── .github/
 │   └── workflows/
 │       ├── ci.yml                 # PR CI — delegates to shared workflow
 │       └── publish.yml            # NPM publish — delegates to shared workflow
+├── docs/
+│   ├── improvements.md            # Known improvement opportunities
+│   ├── index.md                   # Documentation entry point
+│   ├── project-structure.md       # This file
+│   └── release.md                 # Release instructions
 ├── config/
 │   └── environment.js             # Default config with env var overrides
 ├── src/


### PR DESCRIPTION
## Summary

- **docs/project-structure.md**: File tree still showed `improvements.md` and `project-structure.md` under `.claude/` after they were moved to `docs/`. Updated to reflect the current structure with `.claude/CLAUDE.md` as the only file in `.claude/` and added the `docs/` directory listing.

## Context Review Results

- **Track A (Separation of Concerns)**: Fixed stale file tree. Otherwise clean -- CLAUDE.md is thin, docs/index.md properly references project-structure.md and improvements.md.
- **Track B (Directive Quality)**: No issues. Clear, actionable documentation.
- **Track C (Verification Coverage)**: project-structure.md has thorough test documentation.

## Test plan
- [ ] Verify file tree in project-structure.md matches actual repo layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)