### PR TITLE
fix: fix throw-void bug and eliminate double casts via .d.ts

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -23,16 +23,6 @@ import type { Server } from 'http';
 
 export { default as Request } from './request.js';
 
-interface RestServerConfig {
-  port: number;
-  dir: string;
-  camelCaseRoutes?: boolean;
-  enableHealthCheck?: boolean;
-  origin?: string | string[];
-  methods?: string[];
-  trustProxy?: boolean;
-}
-
 export default class RestServer {
   static instance: RestServer;
 
@@ -57,15 +47,15 @@ export default class RestServer {
   async init(): Promise<void> {
     await this.setupRouter();
 
-    const { port } = (config as unknown as Record<string, RestServerConfig>).restServer;
+    const { port } = config.restServer;
 
     // start REST server
     this.server = this.api.listen(port);
-    (log as unknown as Record<string, (msg: string) => void>).title(`API Server is listening on port ${port}`);
+    log.title(`API Server is listening on port ${port}`);
   }
 
   async setupRouter(): Promise<void> {
-    const { camelCaseRoutes, dir, enableHealthCheck } = (config as unknown as Record<string, RestServerConfig>).restServer;
+    const { camelCaseRoutes, dir, enableHealthCheck } = config.restServer;
     this.setupGlobalMiddleware();
 
     try {
@@ -73,13 +63,14 @@ export default class RestServer {
 
       if (enableHealthCheck) this.api.get('/health', (_req: ExpressRequest, res: ExpressResponse) => res.sendStatus(200));
     } catch (error) {
-      if ((config as Record<string, unknown>).debug) console.log(error);
-      throw (log as unknown as Record<string, (msg: string) => void>).error(`Unable to dynamically configure routes from files in ${dir}`);
+      if (config.debug) console.log(error);
+      log.error(`Unable to dynamically configure routes from files in ${dir}`);
+      throw new Error(`Unable to dynamically configure routes from files in ${dir}`);
     }
   }
 
   setupGlobalMiddleware(): void {
-    const { origin, methods, trustProxy } = (config as unknown as Record<string, RestServerConfig>).restServer;
+    const { origin, methods, trustProxy } = config.restServer;
 
     if (trustProxy) this.api.set('trust proxy', true);
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -12,16 +12,17 @@ export type RouteHandlers = Record<string, Record<string, RequestHandler | Reque
 export default class Request {
   static stateProp = '__stonyxState';
 
-  static getState(req: Record<string, unknown>): RequestState {
+  static getState(req: ExpressRequest): RequestState {
     const { stateProp } = Request;
-    if (req[stateProp] !== undefined) return req[stateProp] as RequestState;
+    const record = req as unknown as Record<string, unknown>;
+    if (record[stateProp] !== undefined) return record[stateProp] as RequestState;
 
-    req[stateProp] = {};
-    return req[stateProp] as RequestState;
+    record[stateProp] = {};
+    return record[stateProp] as RequestState;
   }
 
   static sendStatusResponse(res: ExpressResponse, status: number): void {
-    const statusMap = (config as Record<string, Record<string, unknown>>).restServer?.statusMap as Record<number, string> || {};
+    const statusMap = config.restServer?.statusMap ?? {};
     const message = statusMap[status] || '';
 
     if (message) {
@@ -56,7 +57,7 @@ export default class Request {
         (expressInstance as unknown as Record<string, (route: string, handler: (req: ExpressRequest, res: ExpressResponse) => Promise<void>) => void>)[method](route, async (req: ExpressRequest, res: ExpressResponse) => {
           // Run auth after route matching so request.params is populated
           if (this.auth) {
-            const status = this.auth(req, getState(req as unknown as Record<string, unknown>));
+            const status = this.auth(req, getState(req));
             if (status) return sendStatusResponse(res, status);
           }
 
@@ -66,15 +67,15 @@ export default class Request {
 
           // Run middleware
           while(callStack.length) {
-            response = await callStack.shift()!.bind(this)(req, getState(req as unknown as Record<string, unknown>));
+            response = await callStack.shift()!.bind(this)(req, getState(req));
             if (response !== undefined) break;
           }
 
-          if (response === undefined) response = await mainCall(req, getState(req as unknown as Record<string, unknown>));
+          if (response === undefined) response = await mainCall(req, getState(req));
           if (Number.isInteger(response)) return sendStatusResponse(res, response as number);
 
           // Handle redirect if set via call state object
-          const state = getState(req as unknown as Record<string, unknown>);
+          const state = getState(req);
           const { redirect } = state;
           if (redirect) return res.redirect(redirect as string);
 

--- a/src/types/stonyx-logs.d.ts
+++ b/src/types/stonyx-logs.d.ts
@@ -18,5 +18,8 @@ declare module '@stonyx/logs' {
     [key: string]: unknown;
     constructor(options?: Partial<LogOptions>);
     defineType(type: string, setting: ColorSetting, options?: Partial<LogOptions> | null): void;
+    error(message: string): void;
+    warn(message: string): void;
+    title(message: string): void;
   }
 }

--- a/src/types/stonyx.d.ts
+++ b/src/types/stonyx.d.ts
@@ -1,5 +1,22 @@
 declare module 'stonyx/config' {
-  const config: Record<string, Record<string, unknown>>;
+  interface RestServerConfig {
+    port: number;
+    dir: string;
+    camelCaseRoutes?: boolean;
+    enableHealthCheck?: boolean;
+    origin?: string | string[];
+    methods?: string[];
+    trustProxy?: boolean;
+    statusMap?: Record<number, string>;
+  }
+
+  interface Config {
+    restServer: RestServerConfig;
+    debug?: boolean;
+    [key: string]: unknown;
+  }
+
+  const config: Config;
   export default config;
 }
 


### PR DESCRIPTION
## Summary
- Fixed `throw log.error(...)` which threw `undefined` (log.error returns void) — now logs the error then throws a proper Error
- Typed `stonyx/config` with `RestServerConfig` interface — eliminates 3 double casts in main.ts
- Added `error()`, `title()`, `warn()` methods to Log class .d.ts — eliminates 2 double casts
- Changed `getState()` to accept `ExpressRequest` — eliminates 4 double casts in request.ts
- Also removed config cast in `sendStatusResponse`

Closes #27

## Test plan
- [x] TypeScript compilation passes
- [x] Full test suite passes (19/19)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)