### PR TITLE
docs: add project-level SME agent templates

### DIFF
--- a/docs/agents/architect.md
+++ b/docs/agents/architect.md
@@ -1,0 +1,40 @@
+# SME Template: Architect — Stonyx REST Server
+
+> **Inherits from:** `beatrix-shared/docs/framework/templates/agents/architect.md`
+> Load the base template first, then layer this project-specific context on top.
+
+## Project Context
+
+**Repo:** `abofs/stonyx-rest-server`
+**Framework:** HTTP server module for the Stonyx ecosystem
+**Domain:** Express-based REST server with dynamic route registration from file-system discovery, built-in CORS/JSON middleware, per-request authorization hooks, and request state management
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Language | TypeScript (ES Modules) |
+| HTTP Framework | Express 5 |
+| CORS | `cors` npm package |
+| Framework Integration | Stonyx (auto-discovered as `@stonyx/rest-server` module) |
+| Testing | QUnit + Sinon |
+| Build | `tsc` with dual configs (src and test) |
+
+## Architecture Patterns
+
+- **Singleton server:** `RestServer` class enforces a single instance; other modules (ORM, OAuth) access it via `RestServer.instance` to mount additional routes after initialization
+- **File-based route discovery:** `forEachFileImport` scans the configured `requests` directory, instantiates each exported `Request` subclass, and mounts it as an Express sub-app at `/{filename}` (with optional camelCase conversion)
+- **Request class abstraction:** Each route file exports a class extending `Request` with a `handlers` object mapping HTTP methods to route paths and handler functions — handlers return integers for status codes, objects for JSON responses, or `undefined` for 200 OK
+- **Middleware call stack:** Handler values can be arrays of functions; the stack processes left-to-right, short-circuiting if any middleware returns a non-undefined value — the last function is the main handler
+- **Per-request auth hook:** The optional `auth(req, state)` method on Request subclasses runs after Express route matching (so `req.params` is populated) but before any handler — returning a status code blocks the request
+- **Request state bag:** `Request.getState(req)` attaches a `__stonyxState` object to the Express request; handlers share state through this object, and special keys (`redirect`, `pipe`) trigger response behaviors
+- **Mount-point architecture:** Each Request class creates its own Express app (`express()`) that gets mounted as sub-middleware — this isolates route namespaces and allows independent route registration
+
+## Live Knowledge
+
+- The `mountRoute` method is public and used by other modules (ORM mounts `orm-request`, OAuth mounts `auth-request`) — any changes to its signature or behavior break downstream module integration
+- Express 5 is used (not Express 4) — this affects error handling, path matching, and middleware behavior; review Express 5 migration notes for any pattern changes
+- The `statusMap` config option maps status codes to custom message strings — if a mapped status is returned from a handler, the response body changes from Express's default to the custom message
+- `trustProxy` must be enabled (`REST_TRUST_PROXY=true`) when running behind a load balancer (AWS ALB/ELB) for correct `req.protocol` detection — this affects any code that builds URLs from the request protocol
+- The health check endpoint (`GET /health`) is registered last, after all route files — it can be disabled via `REST_HEALTH_CHECK_DISABLE=true` environment variable
+- The `pipe` state key enables streaming responses (e.g., file downloads) by piping a readable source directly to the Express response with optional custom headers

--- a/docs/agents/qa-test-engineer.md
+++ b/docs/agents/qa-test-engineer.md
@@ -1,0 +1,37 @@
+# SME Template: QA Test Engineer — Stonyx REST Server
+
+> **Inherits from:** `beatrix-shared/docs/framework/templates/agents/qa-test-engineer.md`
+> Load the base template first, then layer this project-specific context on top.
+
+## Project Context
+
+**Repo:** `abofs/stonyx-rest-server`
+**Framework:** HTTP server module for the Stonyx ecosystem
+**Domain:** Express-based REST server with dynamic routing, CORS, auth hooks, and request middleware
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Test Runner | QUnit (via `stonyx test`) |
+| Mocking | Sinon |
+| Build (tests) | `tsc -p tsconfig.test.json` (outputs to `dist-test/`) |
+| Test Command | `pnpm build && pnpm build:test && stonyx test 'dist-test/test/**/*-test.js'` |
+| Test Fixtures | `test/sample/` with sample request classes for route testing |
+| Test Config | `test/config/environment.js` with port and directory overrides |
+
+## Architecture Patterns
+
+- **Three test tiers:** `test/unit/` for Request class logic and handler behavior, `test/integration/` for full server lifecycle with HTTP requests, `test/sample/` for fixture request classes
+- **Server lifecycle in tests:** Integration tests must start and stop the server (`RestServer.init()` / `RestServer.close()`) — the singleton pattern means tests must reset `RestServer.instance` between runs
+- **Port isolation:** Test config should use a non-default port to avoid conflicts with running development servers — the default is `2666`
+
+## Live Knowledge
+
+- The `RestServer.close()` method calls both `server.closeAllConnections()` and `server.close()` — tests that don't call close will leave the port bound, causing subsequent test runs to fail with `EADDRINUSE`
+- Handler return value semantics are critical test targets: `undefined` = 200 OK, integer = HTTP status, object = JSON body, non-object truthy value = 500 error — verify all four paths
+- The middleware call stack (array handlers) processes left-to-right with short-circuit — test that early middleware returning a value prevents the main handler from executing
+- Auth hook tests should verify that `req.params` is populated when `auth()` runs (it executes after route matching) — this is a key architectural guarantee that route-specific auth depends on
+- The `redirect` and `pipe` state keys in `Request.getState(req)` trigger special response handling — test that these take priority over normal handler return values
+- Request class discovery via `forEachFileImport` depends on the `dir` config and `camelCaseRoutes` flag — test both raw filenames (`my-route` maps to `/my-route`) and camelCase conversion (`myRoute` maps to `/myRoute`)
+- The `statusMap` config transforms status code responses — test that a mapped status sends the custom message body instead of Express's default status text

--- a/docs/agents/security-reviewer.md
+++ b/docs/agents/security-reviewer.md
@@ -1,0 +1,36 @@
+# SME Template: Security Reviewer — Stonyx REST Server
+
+> **Inherits from:** `beatrix-shared/docs/framework/templates/agents/security-reviewer.md`
+> Load the base template first, then layer this project-specific context on top.
+
+## Project Context
+
+**Repo:** `abofs/stonyx-rest-server`
+**Framework:** HTTP server module for the Stonyx ecosystem
+**Domain:** Express-based REST server handling HTTP routing, CORS, JSON body parsing, authorization hooks, and request middleware for all Stonyx web-facing applications
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| HTTP Framework | Express 5 |
+| CORS | `cors` npm package (configurable origin and methods) |
+| Body Parsing | `express.json()` (built-in) |
+| Auth Model | Per-request-class `auth(req, state)` hooks |
+
+## Architecture Patterns
+
+- **CORS configuration surface:** Origins and methods are configurable via `config.restServer.origin` and `config.restServer.methods` — default is `origin: '*'` (wide open) and all standard methods
+- **Auth hook execution timing:** Authorization runs AFTER Express route matching, meaning `req.params`, `req.query`, and `req.body` are all populated — auth logic can make decisions based on the full request context
+- **Status code response handling:** Integer returns from handlers and auth hooks are sent as HTTP status codes via `sendStatusResponse` — the `statusMap` config can override response bodies for specific codes
+- **Sub-app isolation:** Each Request class mounts as an independent Express app, inheriting global middleware (CORS, JSON) but not each other's route-specific middleware
+
+## Live Knowledge
+
+- The default CORS origin is `'*'` — production deployments must override this to restrict allowed origins; the `origin` config accepts both strings and arrays for multiple origins
+- Request handlers receive raw Express `req` objects — any header, cookie, or body parsing happens via Express middleware, and handler code must validate inputs since there is no schema validation layer built in
+- The `auth` hook returning `undefined` means "authorized" — returning any integer means "rejected with that status code"; a common mistake is returning `0` (falsy but not undefined), which would send a `0` status
+- The `redirect` and `pipe` state keys bypass normal JSON response handling — ensure redirect targets are validated to prevent open redirect vulnerabilities, and pipe sources are trusted streams
+- `x-powered-by` is disabled on all sub-apps (`api.disable('x-powered-by')`) — this is set in the Request constructor, reducing server fingerprinting
+- The `trustProxy` setting directly controls Express's `trust proxy` behavior — when enabled, `X-Forwarded-For`, `X-Forwarded-Proto`, and `X-Forwarded-Host` headers are trusted, which affects IP resolution and protocol detection
+- Error handling in handlers uses a basic pattern: thrown errors propagate to Express's default error handler — there is no global error-catching middleware, so unhandled async rejections in handlers may produce unstructured 500 responses

--- a/docs/agents/validation-loop-team.md
+++ b/docs/agents/validation-loop-team.md
@@ -1,0 +1,35 @@
+# SME Template: Validation Loop Team — Stonyx REST Server
+
+> **Inherits from:** `beatrix-shared/docs/framework/templates/agents/validation-loop-team.md`
+> Load the base template first, then layer this project-specific context on top.
+
+## Project Context
+
+**Repo:** `abofs/stonyx-rest-server`
+**Framework:** HTTP server module for the Stonyx ecosystem
+**Domain:** Dynamic Express-based REST server powering HTTP endpoints for all Stonyx applications — the transport layer that ORM and OAuth modules mount their routes onto
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Language | TypeScript (ES Modules) |
+| HTTP Framework | Express 5 |
+| CORS | `cors` npm package |
+| CI | GitHub Actions (`ci.yml`) |
+| Testing | QUnit + Sinon |
+
+## Architecture Patterns
+
+- **Module mount point:** Other Stonyx modules call `RestServer.instance.mountRoute(RequestClass, { name, options })` to register their routes — this is the primary integration contract
+- **Handler dispatch pipeline:** Route matching -> auth hook -> middleware stack -> main handler -> response serialization (status code, JSON object, redirect, or pipe) — each stage can short-circuit
+- **Global middleware first:** CORS and JSON body parsing are applied to the root Express app before any routes mount — all sub-apps inherit these
+
+## Live Knowledge
+
+- The `mountRoute` public API is consumed by `@stonyx/orm` (for ORM request routes) and `@stonyx/oauth` (for auth routes) — changes to `mountRoute` signature, the `registerCalls()` contract, or the `expressInstance` property pattern break these consumers
+- Express 5 uses different path matching rules than Express 4 — parameter patterns, regex routes, and trailing slash handling may behave differently; validate route patterns against Express 5 documentation
+- The server only has three source files (`main.ts`, `request.ts`, `types/`) — the small surface area means most changes have outsized impact; even minor refactors to `Request.registerCalls()` affect every downstream route
+- The `makeArray` utility from `@stonyx/utils/object` normalizes handler values (single function or array) — validation should confirm that both forms produce identical execution behavior
+- Published package includes only `dist/`, `config/`, and `README.md` — verify no source maps or test artifacts are included in the npm package
+- The health check endpoint (`GET /health`) returning 200 is the standard liveness probe — disabling it via `REST_HEALTH_CHECK_DISABLE` affects deployment readiness checks in production


### PR DESCRIPTION
## Summary
- Add `docs/agents/` directory with SME templates for architect, security-reviewer, qa-test-engineer, and validation-loop-team roles
- Templates provide REST server-specific context overlays (Express 5, dynamic route discovery, Request class patterns, auth hooks, mountRoute API) that layer on top of beatrix-shared base templates
- Content derived from actual source analysis of `main.ts`, `request.ts`, and the three-file architecture

## Test plan
- [ ] Verify each template follows the exact format: title, inherits-from block, project context, tech stack table, architecture patterns, live knowledge
- [ ] Confirm architecture patterns reference actual Express 5 usage, handler return value semantics, and middleware call stack behavior
- [ ] Check that security-reviewer template correctly identifies CORS defaults, auth hook timing, redirect/pipe state keys, and trustProxy implications

🤖 Generated with [Claude Code](https://claude.com/claude-code)