### PR TITLE
fix: remove redundant [skip ci] check from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,6 @@ permissions:
 
 jobs:
   publish:
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     uses: abofs/stonyx-workflows/.github/workflows/npm-publish.yml@main
     with:
       version-type: ${{ github.event.inputs.version-type }}


### PR DESCRIPTION
## Summary
- Remove the manual `if: "!contains(github.event.head_commit.message, '[skip ci]')"` condition from the `publish` job in `publish.yml`
- GitHub Actions natively handles `[skip ci]` in commit titles by skipping all workflows
- The manual check breaks squash merges because it inspects the full commit body, which may contain `[skip ci]` from intermediate release commits

Fixes abofs/stonyx-workflows#12

🤖 Generated with [Claude Code](https://claude.com/claude-code)