### PR TITLE
fix: test suite runs 19/19 green (#33)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc -p tsconfig.test.json",
-    "test": "pnpm build && pnpm typecheck && NODE_OPTIONS='--import tsx' stonyx test 'test/**/*-test.ts'",
+    "test": "pnpm build && pnpm typecheck && NODE_ENV=test node --import tsx/esm --import ./test/setup.ts node_modules/qunit/bin/qunit.js 'test/**/*-test.ts'",
     "prepublishOnly": "npm test"
   },
   "author": "Stone Costa",
@@ -42,10 +42,10 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^5.1.0",
-    "stonyx": "0.2.3-beta.12"
+    "stonyx": "0.2.3-beta.53"
   },
   "devDependencies": {
-    "@stonyx/utils": "0.2.3-beta.7",
+    "@stonyx/utils": "0.2.3-beta.23",
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.6",
     "@types/node": "^25.5.2",
@@ -55,5 +55,11 @@
     "sinon": "^21.0.0",
     "tsx": "^4.21.0",
     "typescript": "^5.8.3"
+  },
+  "pnpm": {
+    "overrides": {
+      "stonyx": "0.2.3-beta.53",
+      "@stonyx/utils": "0.2.3-beta.23"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  stonyx: 0.2.3-beta.53
+  '@stonyx/utils': 0.2.3-beta.23
+
 importers:
 
   .:
@@ -15,12 +19,12 @@ importers:
         specifier: ^5.1.0
         version: 5.2.1
       stonyx:
-        specifier: 0.2.3-beta.12
-        version: 0.2.3-beta.12
+        specifier: 0.2.3-beta.53
+        version: 0.2.3-beta.53
     devDependencies:
       '@stonyx/utils':
-        specifier: 0.2.3-beta.7
-        version: 0.2.3-beta.7
+        specifier: 0.2.3-beta.23
+        version: 0.2.3-beta.23
       '@types/cors':
         specifier: ^2.8.17
         version: 2.8.19
@@ -216,8 +220,11 @@ packages:
   '@sinonjs/samsam@9.0.3':
     resolution: {integrity: sha512-ZgYY7Dc2RW+OUdnZ1DEHg00lhRt+9BjymPKHog4PRFzr1U3MbK57+djmscWyKxzO1qfunHqs4N45WWyKIFKpiQ==}
 
-  '@stonyx/utils@0.2.3-beta.7':
-    resolution: {integrity: sha512-SF6ZZZJ/f1n/+SJJDj8BJdlgvv+WDLGWGUMIkwTpruA5jv/AYJqSoVIgTpYfuMTnYDIsp3KoruaIKy/qd2ETPQ==}
+  '@stonyx/logs@1.0.1-beta.16':
+    resolution: {integrity: sha512-6UccOlU3hnVDKSruFZ/uGXBjK/i8USNjjc7me3ooUxSVbSn+tWhdgkWH/CWDymmvOz+A/FBdDD3dPr1nchbZqQ==}
+
+  '@stonyx/utils@0.2.3-beta.23':
+    resolution: {integrity: sha512-6LRYN4FA/bYFp3r3/1dUuByC76o3QOMm1n+tot09oi0SRmYyGwgPigAZC0JX2wqkw4Fc9rYyhTLqY8o1g2QOMA==}
 
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
@@ -377,9 +384,6 @@ packages:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
 
-  fs@0.0.1-security:
-    resolution: {integrity: sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==}
-
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -429,9 +433,6 @@ packages:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
-  inherits@2.0.3:
-    resolution: {integrity: sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==}
-
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
@@ -469,9 +470,6 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
-  node-chronicle@0.2.0:
-    resolution: {integrity: sha512-se9NsW67UZqDFbK/+Rbml9KdCVTwzaadIgL4NDBcDpLMhOf1qerRxXicE+/dBsoyhDqWCwAFbBjR3iytF3gepA==}
-
   node-watch@0.7.3:
     resolution: {integrity: sha512-3l4E8uMPY1HdMMryPRUAl+oIHtXtyiTlIiESNSVSNxcPfzAFzeTbXFQkZfAwBbo0B1qMSG8nUABx+Gd+YrbKrQ==}
     engines: {node: '>=6'}
@@ -498,19 +496,9 @@ packages:
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
-  path@0.12.7:
-    resolution: {integrity: sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==}
-
-  process@0.11.10:
-    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
-    engines: {node: '>= 0.6.0'}
-
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
-
-  punycode@1.4.1:
-    resolution: {integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==}
 
   qs@6.15.0:
     resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
@@ -573,8 +561,8 @@ packages:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
-  stonyx@0.2.3-beta.12:
-    resolution: {integrity: sha512-bpGXJ1J7MnBxAJrCm7gVdFzUU0ulP66nUlykqndXGFviWRbELilZE6oRbdcGDaOHUjLJ64NM1nO6lS8DezIhaA==}
+  stonyx@0.2.3-beta.53:
+    resolution: {integrity: sha512-lUFJck8Pr21vnKEdmEa955UUODGrVkqk+zX5q/YEueTcurBX7N+vZg4ouB3Gi1fU9gTLGdENWjcCycWCM6Byug==}
     hasBin: true
 
   supports-color@7.2.0:
@@ -616,13 +604,6 @@ packages:
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
-
-  url@0.11.4:
-    resolution: {integrity: sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==}
-    engines: {node: '>= 0.4'}
-
-  util@0.10.4:
-    resolution: {integrity: sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==}
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -724,7 +705,11 @@ snapshots:
       '@sinonjs/commons': 3.0.1
       type-detect: 4.1.0
 
-  '@stonyx/utils@0.2.3-beta.7': {}
+  '@stonyx/logs@1.0.1-beta.16':
+    dependencies:
+      chalk: 5.6.2
+
+  '@stonyx/utils@0.2.3-beta.23': {}
 
   '@types/body-parser@1.19.6':
     dependencies:
@@ -934,8 +919,6 @@ snapshots:
 
   fresh@2.0.0: {}
 
-  fs@0.0.1-security: {}
-
   fsevents@2.3.3:
     optional: true
 
@@ -989,8 +972,6 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  inherits@2.0.3: {}
-
   inherits@2.0.4: {}
 
   ipaddr.js@1.9.1: {}
@@ -1013,13 +994,6 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  node-chronicle@0.2.0:
-    dependencies:
-      chalk: 5.6.2
-      fs: 0.0.1-security
-      path: 0.12.7
-      url: 0.11.4
-
   node-watch@0.7.3: {}
 
   object-assign@4.1.1: {}
@@ -1038,19 +1012,10 @@ snapshots:
 
   path-to-regexp@8.4.2: {}
 
-  path@0.12.7:
-    dependencies:
-      process: 0.11.10
-      util: 0.10.4
-
-  process@0.11.10: {}
-
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
-
-  punycode@1.4.1: {}
 
   qs@6.15.0:
     dependencies:
@@ -1150,10 +1115,10 @@ snapshots:
 
   statuses@2.0.2: {}
 
-  stonyx@0.2.3-beta.12:
+  stonyx@0.2.3-beta.53:
     dependencies:
-      '@stonyx/utils': 0.2.3-beta.7
-      node-chronicle: 0.2.0
+      '@stonyx/logs': 1.0.1-beta.16
+      '@stonyx/utils': 0.2.3-beta.23
 
   supports-color@7.2.0:
     dependencies:
@@ -1188,15 +1153,6 @@ snapshots:
   undici-types@7.18.2: {}
 
   unpipe@1.0.0: {}
-
-  url@0.11.4:
-    dependencies:
-      punycode: 1.4.1
-      qs: 6.15.0
-
-  util@0.10.4:
-    dependencies:
-      inherits: 2.0.3
 
   vary@1.1.2: {}
 

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,22 @@
+// Custom test setup for stonyx-rest-server.
+//
+// Works around a race in stonyx's cli/test-setup.js: that setup calls
+// `new Stonyx(config, cwd)` but does NOT await `Stonyx.ready`, so qunit
+// proceeds to load test files before the async `Stonyx.start()` has
+// flipped `Stonyx.initialized = true`. Integration tests that touch
+// stonyx internals at module load then hit the "Stonyx has not been
+// initialized yet" getter guard.
+//
+// This custom setup mirrors stonyx's but awaits `Stonyx.ready` before
+// returning. It runs as a `--import` loader, so its top-level-await
+// keeps qunit's test-file loading blocked until Stonyx is fully
+// initialized.
+import { pathToFileURL } from 'url';
+
+const cwd = process.cwd();
+
+const { default: Stonyx } = await import('stonyx');
+const { default: config } = await import(pathToFileURL(`${cwd}/config/environment.js`).href);
+
+new Stonyx(config, cwd);
+await Stonyx.ready;

--- a/test/zz-exit-test.ts
+++ b/test/zz-exit-test.ts
@@ -1,0 +1,17 @@
+// Force-exit hook for qunit runs.
+//
+// Tracks stonyx#55: when a stonyx module binds a port during init
+// (rest-server binds 2666), that server keeps the event loop alive
+// after qunit finishes. The framework ships a runEnd hook via
+// `stonyx test` CLI, but this repo invokes qunit directly (bypassing
+// the CLI) to work around the pnpm .bin/qunit shim issue, so we need
+// the hook here.
+//
+// Named `zz-` so alphabetical test-file order places it last, after
+// all real test files have registered with QUnit.
+import QUnit from 'qunit';
+
+// @types/qunit is missing `.on`; it exists at runtime.
+(QUnit as unknown as { on: (event: string, handler: () => void) => void }).on('runEnd', () => {
+  setImmediate(() => process.exit(process.exitCode ?? 0));
+});


### PR DESCRIPTION
## Summary
- Replace broken `stonyx test` (pnpm shim not parseable by tsx) with direct qunit invocation under tsx/esm
- Add `test/setup.ts` that awaits `Stonyx.ready` before yielding (fixes init race)
- Add `test/zz-exit-test.ts` with `QUnit.on('runEnd')` to force-exit after express keeps port 2666 open
- Bump stonyx → 0.2.3-beta.53 and @stonyx/utils → 0.2.3-beta.23 (needed for .ts fixture support)

## Context
Sprint 45 recipe, same as applied to stonyx-oauth#23 and stonyx-orm#115. The utils bump is required because `test/sample/requests/` was migrated to .ts in #31 but forEachFileImport was filtering .js only — fixed upstream in abofs/stonyx-utils#36.

Closes #33.

## Test plan
- [x] Local: 19/19 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)