### PR TITLE
chore: bump stonyx override to beta.61 (#35)

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "pnpm": {
     "overrides": {
-      "stonyx": "0.2.3-beta.53",
+      "stonyx": "0.2.3-beta.61",
       "@stonyx/utils": "0.2.3-beta.23"
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  stonyx: 0.2.3-beta.53
+  stonyx: 0.2.3-beta.61
   '@stonyx/utils': 0.2.3-beta.23
 
 importers:
@@ -19,8 +19,8 @@ importers:
         specifier: ^5.1.0
         version: 5.2.1
       stonyx:
-        specifier: 0.2.3-beta.53
-        version: 0.2.3-beta.53
+        specifier: 0.2.3-beta.61
+        version: 0.2.3-beta.61
     devDependencies:
       '@stonyx/utils':
         specifier: 0.2.3-beta.23
@@ -561,8 +561,8 @@ packages:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
-  stonyx@0.2.3-beta.53:
-    resolution: {integrity: sha512-lUFJck8Pr21vnKEdmEa955UUODGrVkqk+zX5q/YEueTcurBX7N+vZg4ouB3Gi1fU9gTLGdENWjcCycWCM6Byug==}
+  stonyx@0.2.3-beta.61:
+    resolution: {integrity: sha512-lBs/YAvKmyJfhnz5vFe3EyrbTqiwqmoNbZTaeub+WXnc5M8HcOrFOtyycyvW1UKDbvRrqL9GQMZV3Emw2DcrOQ==}
     hasBin: true
 
   supports-color@7.2.0:
@@ -1115,7 +1115,7 @@ snapshots:
 
   statuses@2.0.2: {}
 
-  stonyx@0.2.3-beta.53:
+  stonyx@0.2.3-beta.61:
     dependencies:
       '@stonyx/logs': 1.0.1-beta.16
       '@stonyx/utils': 0.2.3-beta.23


### PR DESCRIPTION
## Summary

- Bump `pnpm.overrides.stonyx` from `0.2.3-beta.53` → `0.2.3-beta.61` to pick up the TS-migration sweep (stonyx#59, #60, #61, #62, #67).
- `config/environment.js` stays out of the tree post-install — the stonyx#58 clobber guard works at beta.61.

## Test plan

- [ ] CI: `test/test` passes on the canonical `stonyx-rest-server` checkout path (local worktree tests fail due to a known stonyx standalone-transform heuristic that uses `rootPath.includes('stonyx-')` — fragile in worktrees; filed as framework follow-up).
- [ ] CI: `publish/publish` + `cascade/dispatch` green.

Closes #35