### PR TITLE
fix(config): ship config/environment.js not .ts (#37)

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -1,14 +1,3 @@
-interface RestServerEnvironmentConfig {
-  enableHealthCheck: boolean;
-  origin: string;
-  methods: string;
-  dir: string;
-  port: string | number;
-  trustProxy: boolean;
-  logColor: string;
-  logMethod: string;
-}
-
 const {
   REST_CORS_ORIGIN,
   REST_CORS_METHODS,
@@ -18,7 +7,7 @@ const {
   REST_TRUST_PROXY
 } = process.env;
 
-const config: RestServerEnvironmentConfig = {
+const config = {
   enableHealthCheck: REST_HEALTH_CHECK_DISABLE !== 'true',
   origin: REST_CORS_ORIGIN ?? '*',
   methods: REST_CORS_METHODS ?? 'GET,POST,PATCH,PUT,DELETE',

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "stonyx-async",
     "stonyx-module"
   ],
-  "version": "0.2.1-beta.59",
+  "version": "0.2.1-beta.60",
   "description": "Rest Server Module for Stonyx Framework",
   "repository": {
     "type": "git",

--- a/test/unit/publish-surface-test.ts
+++ b/test/unit/publish-surface-test.ts
@@ -1,0 +1,35 @@
+// Regression test for stonyx-rest-server#37.
+//
+// The package must publish `config/environment.js` (plain JS) and must NOT
+// publish `config/environment.ts`. Node refuses to type-strip inside
+// `node_modules`, so if we ship a `.ts` here the stonyx module loader
+// dynamic-import of this config will crash consumers at parse time.
+//
+// This test invokes `npm pack --dry-run --json` and asserts the tarball
+// entry list contains `config/environment.js` and does not contain
+// `config/environment.ts`.
+import QUnit from 'qunit';
+import { execFileSync } from 'child_process';
+
+const { module, test } = QUnit;
+
+module('[Unit] Publish surface', function () {
+  test('config/environment.js is published and .ts is not', function (assert) {
+    const stdout = execFileSync('npm', ['pack', '--dry-run', '--json'], {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+    });
+    const report = JSON.parse(stdout);
+    const entry = Array.isArray(report) ? report[0] : report;
+    const files = (entry.files ?? []).map((f: { path: string }) => f.path);
+
+    assert.ok(
+      files.includes('config/environment.js'),
+      'published tarball includes config/environment.js'
+    );
+    assert.notOk(
+      files.includes('config/environment.ts'),
+      'published tarball does NOT include config/environment.ts'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Rename `config/environment.ts` to `config/environment.js` and strip the type-only syntax (`interface RestServerEnvironmentConfig` block and the `: RestServerEnvironmentConfig` annotation on `config`). Runtime semantics unchanged — destructure, object literal, and `export default config` preserved exactly.
- Bump patch version `0.2.1-beta.59` -> `0.2.1-beta.60`.
- Add regression test (`test/unit/publish-surface-test.ts`) that runs `npm pack --dry-run --json` and asserts the published tarball contains `config/environment.js` and does NOT contain `config/environment.ts`.

## Why

Closes abofs/stonyx-rest-server#37.

Node refuses to type-strip sources inside `node_modules`, so shipping `config/environment.ts` crashes consumers at parse time when the stonyx module loader dynamic-imports the config. This is the same class of bug as the parent P0 hotfix for the already-promoted `latest`-channel module (stonyx-orm#118); this PR applies the fix on the beta channel before any promotion.

The `.ts` extension was introduced as scope-creep in the "migrate tests to TypeScript" PR (was #31).

## Test plan

- [x] `pnpm test` — all 20 tests pass, including the new publish-surface assertion
- [x] `node --check config/environment.js` — valid JS
- [x] `pnpm typecheck` passes (runs as part of the test script)
- [x] Verified renamed file is tracked at `config/environment.js` and `config/environment.ts` no longer exists in the tree