### PR TITLE
fix: revert package.json version so cascade auto-bump succeeds

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "stonyx-async",
     "stonyx-module"
   ],
-  "version": "0.2.1-beta.60",
+  "version": "0.2.1-beta.59",
   "description": "Rest Server Module for Stonyx Framework",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Reverts \`package.json\` version \`0.2.1-beta.60\` → \`0.2.1-beta.59\` so the publish workflow can compute the next beta and succeed.

## Why

PR #37 manually bumped the version to \`.60\` in the same commit as the config hotfix. The publish workflow then computed \`max(existing betas) + 1 = .60\`, matched the current version, and hit \`pnpm version\` → \`npm error Version not changed\`. The cascade never published, so \`@stonyx/rest-server@beta\` on npm is **still \`0.2.1-beta.59\`** (pre-fix) and continues to ship the broken \`config/environment.ts\`.

Stone flagged this in #dev — the config-js issue is still live on the rest-server beta channel.

Same pattern as the sockets fix earlier today (stonyx-sockets PR #28).

## Test plan

- [ ] CI green
- [ ] After merge, cascade publishes \`0.2.1-beta.60\` to npm
- [ ] \`npm pack @stonyx/rest-server@0.2.1-beta.60\` ships \`config/environment.js\`, not \`.ts\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)