### PR TITLE
fix(rest-server): self-register api log type in RestServer.init

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -45,6 +45,11 @@ export default class RestServer {
   }
 
   async init(): Promise<void> {
+    // Self-register so log.api works even when @stonyx/rest-server is in the
+    // consumer's `dependencies` (stonyx loader only merges devDependencies).
+    const { logColor = 'yellow', logMethod = 'api' } = config.restServer;
+    log.defineType(logMethod, logColor);
+
     await this.setupRouter();
 
     const { port } = config.restServer;

--- a/src/types/stonyx.d.ts
+++ b/src/types/stonyx.d.ts
@@ -8,6 +8,8 @@ declare module 'stonyx/config' {
     methods?: string[];
     trustProxy?: boolean;
     statusMap?: Record<number, string>;
+    logColor?: string;
+    logMethod?: string;
   }
 
   interface Config {
@@ -21,7 +23,13 @@ declare module 'stonyx/config' {
 }
 
 declare module 'stonyx/log' {
-  import type Log from '@stonyx/logs';
+  interface Log {
+    api(message: string): void;
+    error(message: string, ...args: unknown[]): void;
+    title(message: string): void;
+    defineType(type: string, setting: string, options?: Record<string, unknown> | null): void;
+    [key: string]: unknown;
+  }
   const log: Log;
   export default log;
 }

--- a/test/unit/main-test.ts
+++ b/test/unit/main-test.ts
@@ -1,0 +1,47 @@
+import QUnit from 'qunit';
+import sinon from 'sinon';
+import RestServer from '../../src/main.js';
+import log from 'stonyx/log';
+
+const { module, test } = QUnit;
+
+module('[Unit] RestServer', function (hooks) {
+  hooks.afterEach(function () {
+    sinon.restore();
+    // Reset singleton so each test gets a fresh instance.
+    (RestServer as unknown as { instance?: RestServer }).instance = undefined;
+  });
+
+  module('self-registers log type in init() (#40)', function (innerHooks) {
+    innerHooks.afterEach(function () {
+      sinon.restore();
+    });
+
+    test('registers api log type on init', async function (assert) {
+      assert.strictEqual(typeof log.defineType, 'function', 'log.defineType is available');
+
+      const server = new RestServer();
+      // init() may throw later (route discovery / listen failures in the unit
+      // harness) but defineType runs as the first statement, before the throw.
+      try { await server.init(); } catch { /* expected */ }
+
+      assert.strictEqual(typeof log.api, 'function', 'log.api is callable after init');
+
+      try { RestServer.close(); } catch { /* best effort */ }
+    });
+
+    test('idempotent: calling init twice does not throw', async function (assert) {
+      const server1 = new RestServer();
+      try { await server1.init(); } catch { /* expected */ }
+      try { RestServer.close(); } catch { /* best effort */ }
+      (RestServer as unknown as { instance?: RestServer }).instance = undefined;
+
+      const server2 = new RestServer();
+      try { await server2.init(); } catch { /* expected */ }
+
+      assert.strictEqual(typeof log.api, 'function', 'log.api still callable after second init');
+
+      try { RestServer.close(); } catch { /* best effort */ }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements the per-module self-registration pattern decided in abofs/stonyx#75, mirroring the precedent set by abofs/stonyx-sockets#30.

Prepends `log.defineType(logMethod, logColor)` as the first statement of `RestServer.init()` with literal fallbacks (`'api'` / `'yellow'`) matching `config/environment.js`. Ensures `log.api` is callable even when `@stonyx/rest-server` is placed in a consumer's `dependencies` rather than `devDependencies` (where the stonyx loader silently skips config merge).

## Changes

- `src/main.ts` — destructure `logColor`/`logMethod` with literal fallbacks, call `log.defineType` as the first statement of `init()`.
- `src/types/stonyx.d.ts` — add `logColor?`/`logMethod?` to `RestServerConfig`; add `api()`, `title()`, `defineType()` to the `Log` interface.
- `test/unit/main-test.ts` — two unit tests mirroring stonyx-sockets#30: registers api log type on init, and idempotent double-init.

## Cross-links

- abofs/stonyx#75 — architectural decision / rollout plan
- abofs/stonyx-sockets#30 — precedent PR
- Closes #40

## Test plan

- [x] `pnpm build` passes
- [ ] CI green on dev target (local test run skipped per worktree-hang pattern on stonyx < beta.62; trust CI)